### PR TITLE
Overhaul editor integration

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thinktool/client",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thinktool/client",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Client code for Thinktool, shared between web and desktop client.",
   "license": "UNLICENSED",
   "repository": {

--- a/src/client/src/changes.json
+++ b/src/client/src/changes.json
@@ -375,6 +375,10 @@
     {
       "date": "2020-12-19",
       "title": "Fixed an issue with URL updates that would cause the back button to be unable to navigate through history inside Thinktool."
+    },
+    {
+      "date": "2021-01-02",
+      "title": "Continuing overhauling various parts of the application, especially the editor component to make them more testable. This will hopefully reduce the number of bugs in the long term, but may introduce new bugs in the short term."
     }
   ]
 }

--- a/src/client/src/data.ts
+++ b/src/client/src/data.ts
@@ -1,7 +1,7 @@
 import * as Misc from "@johv/miscjs";
 import {Content} from "./data/content";
 
-export {Content, references, backreferences, contentText} from "./data/content";
+export {Content, references, backreferences, contentText, contentEq} from "./data/content";
 
 export interface State {
   things: {[id: string]: ThingData | undefined};

--- a/src/client/src/data.ts
+++ b/src/client/src/data.ts
@@ -1,7 +1,7 @@
-import {Communication} from "@thinktool/shared";
 import * as Misc from "@johv/miscjs";
+import {Content} from "./data/content";
 
-export type Content = Communication.Content;
+export {Content, references, backreferences, contentText} from "./data/content";
 
 export interface State {
   things: {[id: string]: ThingData | undefined};
@@ -270,56 +270,6 @@ export function remove(state: State, removedThing: string): State {
 
 export function otherParents(state: State, child: string, parent?: string): string[] {
   return parents(state, child).filter((p) => p !== parent);
-}
-
-export function contentText(state: State, thing: string): string {
-  function contentText_(thing: string, seen: string[]): string {
-    if (seen.includes(thing)) return "...";
-
-    let result = "";
-    for (const segment of content(state, thing)) {
-      if (typeof segment === "string") {
-        result += segment;
-      } else if (typeof segment.link === "string") {
-        if (exists(state, segment.link)) {
-          result += contentText_(segment.link, [...seen, thing]);
-        } else {
-          result += `[${segment.link}]`;
-        }
-      }
-    }
-
-    return result;
-  }
-
-  return contentText_(thing, []);
-}
-
-// In-line references
-//
-// Items may reference other items in their content. Such items are displayed
-// with the referenced item embedded where the reference is.
-
-export function references(state: State, thing: string): string[] {
-  let result: string[] = [];
-
-  for (const segment of content(state, thing)) {
-    if (typeof segment.link === "string") {
-      result = [...result, segment.link];
-    }
-  }
-
-  return result;
-}
-
-export function backreferences(state: State, thing: string): string[] {
-  let result: string[] = [];
-  for (const other in state.things) {
-    if (references(state, other).includes(thing)) {
-      result = [...result, other];
-    }
-  }
-  return result;
 }
 
 // When the user does something, we need to update both the local state and the

--- a/src/client/src/data/content.ts
+++ b/src/client/src/data/content.ts
@@ -1,0 +1,52 @@
+import * as Shared from "@thinktool/shared";
+import * as D from "../data";
+
+export type Content = Shared.Communication.Content;
+
+export function contentText(state: D.State, thing: string): string {
+  function contentText_(thing: string, seen: string[]): string {
+    if (seen.includes(thing)) return "...";
+
+    let result = "";
+    for (const segment of D.content(state, thing)) {
+      if (typeof segment === "string") {
+        result += segment;
+      } else if (typeof segment.link === "string") {
+        if (D.exists(state, segment.link)) {
+          result += contentText_(segment.link, [...seen, thing]);
+        } else {
+          result += `[${segment.link}]`;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  return contentText_(thing, []);
+}
+
+// Items may reference other items in their content. Such items are displayed
+// with the referenced item embedded where the reference is.
+
+export function references(state: D.State, thing: string): string[] {
+  let result: string[] = [];
+
+  for (const segment of D.content(state, thing)) {
+    if (typeof segment.link === "string") {
+      result = [...result, segment.link];
+    }
+  }
+
+  return result;
+}
+
+export function backreferences(state: D.State, thing: string): string[] {
+  let result: string[] = [];
+  for (const other in state.things) {
+    if (references(state, other).includes(thing)) {
+      result = [...result, other];
+    }
+  }
+  return result;
+}

--- a/src/client/src/data/content.ts
+++ b/src/client/src/data/content.ts
@@ -3,6 +3,17 @@ import * as D from "../data";
 
 export type Content = Shared.Communication.Content;
 
+export function contentEq(a: Content, b: Content): boolean {
+  if (a.length !== b.length) return false;
+
+  for (let i = 0; i < a.length; ++i) {
+    if (typeof a[i] === "string" && a[i] !== b[i]) return false;
+    if (typeof a[i] !== "string" && (typeof b[i] !== "string" || a[i].link !== b[i].link)) return false;
+  }
+
+  return true;
+}
+
 export function contentText(state: D.State, thing: string): string {
   function contentText_(thing: string, seen: string[]): string {
     if (seen.includes(thing)) return "...";

--- a/src/client/src/data/content.ts
+++ b/src/client/src/data/content.ts
@@ -8,7 +8,7 @@ export function contentEq(a: Content, b: Content): boolean {
 
   for (let i = 0; i < a.length; ++i) {
     if (typeof a[i] === "string" && a[i] !== b[i]) return false;
-    if (typeof a[i] !== "string" && (typeof b[i] !== "string" || a[i].link !== b[i].link)) return false;
+    if (typeof a[i] !== "string" && (typeof b[i] === "string" || a[i].link !== b[i].link)) return false;
   }
 
   return true;

--- a/src/client/src/editing.ts
+++ b/src/client/src/editing.ts
@@ -1,14 +1,5 @@
 import * as D from "./data";
 
-export function contentToEditString(content: D.Content): string {
-  let result = "";
-  for (const segment of content) {
-    if (typeof segment === "string") result += segment;
-    else result += `#${segment.link}`;
-  }
-  return result;
-}
-
 export type EditorContent = (string | {link: string; title: string | null})[];
 
 export function collate(content: D.Content, state: D.State): EditorContent {

--- a/src/client/src/editing.ts
+++ b/src/client/src/editing.ts
@@ -96,6 +96,16 @@ export function insertLink(editor: Editor, link: {link: string; title: string}):
   return {content, selection: {from: cursor, to: cursor}};
 }
 
+export function produceContent(editor: Editor): D.Content {
+  return editor.content.map((segment) => {
+    if (typeof segment === "string") {
+      return segment;
+    } else {
+      return {link: segment.link};
+    }
+  });
+}
+
 // #region Paragraphs
 
 // When the user pastes a series of paragraph, the application should split each

--- a/src/client/src/editing.ts
+++ b/src/client/src/editing.ts
@@ -1,16 +1,22 @@
 import * as D from "./data";
 
+export interface Editor {
+  content: EditorContent;
+}
+
 export type EditorContent = (string | {link: string; title: string | null})[];
 export type Range = {from: number; to: number};
 
-export function collate(content: D.Content, state: D.State): EditorContent {
-  return content.map((piece) => {
-    if (typeof piece === "string") {
-      return piece;
-    } else {
-      return {link: piece.link, title: D.exists(state, piece.link) ? D.contentText(state, piece.link) : null};
-    }
-  });
+export function load(content: D.Content, state: D.State): Editor {
+  return {
+    content: content.map((piece) => {
+      if (typeof piece === "string") {
+        return piece;
+      } else {
+        return {link: piece.link, title: D.exists(state, piece.link) ? D.contentText(state, piece.link) : null};
+      }
+    }),
+  };
 }
 
 export function externalLinkRanges(content: EditorContent): Range[] {

--- a/src/client/src/editing.ts
+++ b/src/client/src/editing.ts
@@ -9,6 +9,18 @@ export function contentToEditString(content: D.Content): string {
   return result;
 }
 
+export type EditorContent = (string | {link: string; title: string | null})[];
+
+export function collate(content: D.Content, state: D.State): EditorContent {
+  return content.map((piece) => {
+    if (typeof piece === "string") {
+      return piece;
+    } else {
+      return {link: piece.link, title: D.exists(state, piece.link) ? D.contentText(state, piece.link) : null};
+    }
+  });
+}
+
 // #region Paragraphs
 
 // When the user pastes a series of paragraph, the application should split each

--- a/src/client/src/editing.ts
+++ b/src/client/src/editing.ts
@@ -9,51 +9,6 @@ export function contentToEditString(content: D.Content): string {
   return result;
 }
 
-export function contentFromEditString(editString: string): D.Content {
-  try {
-    let result: D.Content = [];
-    let buffer = "";
-    let readingLink = false;
-
-    function commit() {
-      if (buffer !== "") {
-        if (readingLink) {
-          result.push({link: buffer});
-        } else {
-          result.push(buffer);
-        }
-      } else if (buffer === "" && readingLink) {
-        result.push("#");
-      }
-      buffer = "";
-    }
-
-    for (const ch of [...editString]) {
-      if (ch === "#") {
-        commit();
-        readingLink = true;
-      } else if (readingLink) {
-        if (ch.match(/[a-z0-9]/)) {
-          buffer += ch;
-        } else {
-          commit();
-          readingLink = false;
-          buffer = ch;
-        }
-      } else {
-        buffer += ch;
-      }
-    }
-
-    commit();
-
-    return result;
-  } catch (e) {
-    console.error("Parse error while trying to convert string %o to content: %o", editString, e);
-    return [];
-  }
-}
-
 // #region Paragraphs
 
 // When the user pastes a series of paragraph, the application should split each

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -477,7 +477,7 @@ function ThingOverview(p: {context: Context}) {
           onEditorStateChanged={(editor) => {
             if (T.hasFocus(p.context.tree, T.root(p.context.tree))) {
               p.context.registerActiveEditor({
-                selection: editor.selection,
+                selection: "", // [FIXME] We should get this from editor
                 replaceSelectionWithLink(target, textContent) {
                   editor.replace(target, textContent);
                 },
@@ -637,7 +637,7 @@ function ExpandableItem(props: {
       onEditorStateChanged={(editor) => {
         if (T.hasFocus(props.context.tree, props.node)) {
           props.context.registerActiveEditor({
-            selection: editor.selection,
+            selection: "", // [FIXME] We should get this from FIXME. We should get this from editor
             replaceSelectionWithLink(target, textContent) {
               editor.replace(target, textContent);
             },

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -461,7 +461,10 @@ function ThingOverview(p: {context: Context}) {
           onOpenLink={openLink}
           onJumpLink={jumpLink}
           onFocus={() => p.context.setTree(T.focus(p.context.tree, T.root(p.context.tree)))}
-          content={Data.content(p.context.state, T.thing(p.context.tree, T.root(p.context.tree)))}
+          content={Editor.collate(
+            Data.content(p.context.state, T.thing(p.context.tree, T.root(p.context.tree))),
+            p.context.state,
+          )}
           onEdit={(content) =>
             p.context.setState(
               Data.setContent(p.context.state, T.thing(p.context.tree, T.root(p.context.tree)), content),
@@ -609,7 +612,10 @@ function ExpandableItem(props: {
       onOpenLink={onOpenLink}
       onJumpLink={onJumpLink}
       onFocus={() => props.context.setTree(T.focus(props.context.tree, props.node))}
-      content={Data.content(props.context.state, T.thing(props.context.tree, props.node))}
+      content={Editor.collate(
+        Data.content(props.context.state, T.thing(props.context.tree, props.node)),
+        props.context.state,
+      )}
       onEdit={(content) =>
         props.context.setState(
           Data.setContent(props.context.state, T.thing(props.context.tree, props.node), content),

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -17,6 +17,7 @@ import * as Actions from "./actions";
 import * as Sh from "./shortcuts";
 
 import * as Editor from "./ui/Editor";
+import * as Editing from "./editing";
 import {usePopup} from "./ui/ThingSelectPopup";
 import Toolbar from "./ui/Toolbar";
 import Changelog from "./ui/Changelog";
@@ -460,7 +461,7 @@ function ThingOverview(p: {context: Context}) {
           onOpenLink={openLink}
           onJumpLink={jumpLink}
           onFocus={() => p.context.setTree(T.focus(p.context.tree, T.root(p.context.tree)))}
-          content={Editor.collate(
+          content={Editing.collate(
             Data.content(p.context.state, T.thing(p.context.tree, T.root(p.context.tree))),
             p.context.state,
           )}
@@ -620,7 +621,7 @@ function ExpandableItem(props: {
       onOpenLink={onOpenLink}
       onJumpLink={onJumpLink}
       onFocus={() => props.context.setTree(T.focus(props.context.tree, props.node))}
-      content={Editor.collate(
+      content={Editing.collate(
         Data.content(props.context.state, T.thing(props.context.tree, props.node)),
         props.context.state,
       )}

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -461,6 +461,7 @@ function ThingOverview(p: {context: Context}) {
           onOpenLink={openLink}
           onJumpLink={jumpLink}
           onFocus={() => p.context.setTree(T.focus(p.context.tree, T.root(p.context.tree)))}
+          content={Data.content(p.context.state, T.thing(p.context.tree, T.root(p.context.tree)))}
         />
         <div className="children">
           <Outline context={p.context} />
@@ -599,6 +600,7 @@ function ExpandableItem(props: {
       onOpenLink={onOpenLink}
       onJumpLink={onJumpLink}
       onFocus={() => props.context.setTree(T.focus(props.context.tree, props.node))}
+      content={Data.content(props.context.state, T.thing(props.context.tree, props.node))}
     />
   );
 

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -462,6 +462,11 @@ function ThingOverview(p: {context: Context}) {
           onJumpLink={jumpLink}
           onFocus={() => p.context.setTree(T.focus(p.context.tree, T.root(p.context.tree)))}
           content={Data.content(p.context.state, T.thing(p.context.tree, T.root(p.context.tree)))}
+          onEdit={(content) =>
+            p.context.setState(
+              Data.setContent(p.context.state, T.thing(p.context.tree, T.root(p.context.tree)), content),
+            )
+          }
         />
         <div className="children">
           <Outline context={p.context} />
@@ -601,6 +606,11 @@ function ExpandableItem(props: {
       onJumpLink={onJumpLink}
       onFocus={() => props.context.setTree(T.focus(props.context.tree, props.node))}
       content={Data.content(props.context.state, T.thing(props.context.tree, props.node))}
+      onEdit={(content) =>
+        props.context.setState(
+          Data.setContent(props.context.state, T.thing(props.context.tree, props.node), content),
+        )
+      }
     />
   );
 

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -456,8 +456,6 @@ function ThingOverview(p: {context: Context}) {
       <ParentsOutline context={p.context} />
       <div className="overview-main">
         <Editor.Editor
-          context={p.context}
-          node={T.root(p.context.tree)}
           onAction={(action) => p.context.send("action", {action})}
           onOpenLink={openLink}
           onJumpLink={jumpLink}
@@ -485,6 +483,7 @@ function ThingOverview(p: {context: Context}) {
               });
             }
           }}
+          onOpenExternalUrl={p.context.openExternalUrl}
         />
         <div className="children">
           <Outline context={p.context} />
@@ -617,8 +616,6 @@ function ExpandableItem(props: {
 
   const content = (
     <Editor.Editor
-      context={props.context}
-      node={props.node}
       onAction={(action) => props.context.send("action", {action})}
       onOpenLink={onOpenLink}
       onJumpLink={onJumpLink}
@@ -646,6 +643,7 @@ function ExpandableItem(props: {
           });
         }
       }}
+      onOpenExternalUrl={props.context.openExternalUrl}
     />
   );
 

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -16,7 +16,7 @@ import * as Storage from "./storage";
 import * as Actions from "./actions";
 import * as Sh from "./shortcuts";
 
-import Editor from "./ui/Editor";
+import * as Editor from "./ui/Editor";
 import {usePopup} from "./ui/ThingSelectPopup";
 import Toolbar from "./ui/Toolbar";
 import Changelog from "./ui/Changelog";
@@ -454,7 +454,7 @@ function ThingOverview(p: {context: Context}) {
     <div className="overview">
       <ParentsOutline context={p.context} />
       <div className="overview-main">
-        <Editor
+        <Editor.Editor
           context={p.context}
           node={T.root(p.context.tree)}
           onAction={(action) => p.context.send("action", {action})}
@@ -468,6 +468,9 @@ function ThingOverview(p: {context: Context}) {
             )
           }
           hasFocus={T.hasFocus(p.context.tree, T.root(p.context.tree))}
+          onPastedParagraphs={(paragraphs) =>
+            setAppState(p.context, Editor.onPastedParagraphs(p.context, T.root(p.context.tree), paragraphs))
+          }
         />
         <div className="children">
           <Outline context={p.context} />
@@ -599,7 +602,7 @@ function ExpandableItem(props: {
   const subtree = <Subtree context={props.context} parent={props.node} grandparent={props.parent} />;
 
   const content = (
-    <Editor
+    <Editor.Editor
       context={props.context}
       node={props.node}
       onAction={(action) => props.context.send("action", {action})}
@@ -613,6 +616,9 @@ function ExpandableItem(props: {
         )
       }
       hasFocus={T.hasFocus(props.context.tree, props.node)}
+      onPastedParagraphs={(paragraphs) =>
+        setAppState(props.context, Editor.onPastedParagraphs(props.context, props.node, paragraphs))
+      }
     />
   );
 

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -33,6 +33,7 @@ import * as ReactDOM from "react-dom";
 import undo from "./undo";
 import {Receiver, receiver as createReceiver} from "./receiver";
 import {Message} from "./messages";
+import {contentText} from "./data/content";
 
 function useContext({
   initialState,
@@ -474,6 +475,16 @@ function ThingOverview(p: {context: Context}) {
           onPastedParagraphs={(paragraphs) =>
             setAppState(p.context, Editor.onPastedParagraphs(p.context, T.root(p.context.tree), paragraphs))
           }
+          onEditorStateChanged={(editor) => {
+            if (T.hasFocus(p.context.tree, T.root(p.context.tree))) {
+              p.context.registerActiveEditor({
+                selection: editor.selection,
+                replaceSelectionWithLink(target, textContent) {
+                  editor.replace(target, textContent);
+                },
+              });
+            }
+          }}
         />
         <div className="children">
           <Outline context={p.context} />
@@ -625,6 +636,16 @@ function ExpandableItem(props: {
       onPastedParagraphs={(paragraphs) =>
         setAppState(props.context, Editor.onPastedParagraphs(props.context, props.node, paragraphs))
       }
+      onEditorStateChanged={(editor) => {
+        if (T.hasFocus(props.context.tree, props.node)) {
+          props.context.registerActiveEditor({
+            selection: editor.selection,
+            replaceSelectionWithLink(target, textContent) {
+              editor.replace(target, textContent);
+            },
+          });
+        }
+      }}
     />
   );
 

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -461,7 +461,7 @@ function ThingOverview(p: {context: Context}) {
           onOpenLink={openLink}
           onJumpLink={jumpLink}
           onFocus={() => p.context.setTree(T.focus(p.context.tree, T.root(p.context.tree)))}
-          content={Editing.collate(
+          editor={Editing.load(
             Data.content(p.context.state, T.thing(p.context.tree, T.root(p.context.tree))),
             p.context.state,
           )}
@@ -621,7 +621,7 @@ function ExpandableItem(props: {
       onOpenLink={onOpenLink}
       onJumpLink={onJumpLink}
       onFocus={() => props.context.setTree(T.focus(props.context.tree, props.node))}
-      content={Editing.collate(
+      editor={Editing.load(
         Data.content(props.context.state, T.thing(props.context.tree, props.node)),
         props.context.state,
       )}

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -465,9 +465,9 @@ function ThingOverview(p: {context: Context}) {
             Data.content(p.context.state, T.thing(p.context.tree, T.root(p.context.tree))),
             p.context.state,
           )}
-          onEdit={(content) =>
+          onEdit={(editor) =>
             p.context.setState(
-              Data.setContent(p.context.state, T.thing(p.context.tree, T.root(p.context.tree)), content),
+              Data.setContent(p.context.state, T.thing(p.context.tree, T.root(p.context.tree)), editor.content),
             )
           }
           hasFocus={T.hasFocus(p.context.tree, T.root(p.context.tree))}
@@ -625,9 +625,9 @@ function ExpandableItem(props: {
         Data.content(props.context.state, T.thing(props.context.tree, props.node)),
         props.context.state,
       )}
-      onEdit={(content) =>
+      onEdit={(editor) =>
         props.context.setState(
-          Data.setContent(props.context.state, T.thing(props.context.tree, props.node), content),
+          Data.setContent(props.context.state, T.thing(props.context.tree, props.node), editor.content),
         )
       }
       hasFocus={T.hasFocus(props.context.tree, props.node)}

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -467,7 +467,11 @@ function ThingOverview(p: {context: Context}) {
           )}
           onEdit={(editor) =>
             p.context.setState(
-              Data.setContent(p.context.state, T.thing(p.context.tree, T.root(p.context.tree)), editor.content),
+              Data.setContent(
+                p.context.state,
+                T.thing(p.context.tree, T.root(p.context.tree)),
+                Editing.produceContent(editor),
+              ),
             )
           }
           hasFocus={T.hasFocus(p.context.tree, T.root(p.context.tree))}
@@ -627,7 +631,11 @@ function ExpandableItem(props: {
       )}
       onEdit={(editor) =>
         props.context.setState(
-          Data.setContent(props.context.state, T.thing(props.context.tree, props.node), editor.content),
+          Data.setContent(
+            props.context.state,
+            T.thing(props.context.tree, props.node),
+            Editing.produceContent(editor),
+          ),
         )
       }
       hasFocus={T.hasFocus(props.context.tree, props.node)}

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -460,6 +460,7 @@ function ThingOverview(p: {context: Context}) {
           onAction={(action) => p.context.send("action", {action})}
           onOpenLink={openLink}
           onJumpLink={jumpLink}
+          onFocus={() => p.context.setTree(T.focus(p.context.tree, T.root(p.context.tree)))}
         />
         <div className="children">
           <Outline context={p.context} />
@@ -597,6 +598,7 @@ function ExpandableItem(props: {
       onAction={(action) => props.context.send("action", {action})}
       onOpenLink={onOpenLink}
       onJumpLink={onJumpLink}
+      onFocus={() => props.context.setTree(T.focus(props.context.tree, props.node))}
     />
   );
 

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -467,6 +467,7 @@ function ThingOverview(p: {context: Context}) {
               Data.setContent(p.context.state, T.thing(p.context.tree, T.root(p.context.tree)), content),
             )
           }
+          hasFocus={T.hasFocus(p.context.tree, T.root(p.context.tree))}
         />
         <div className="children">
           <Outline context={p.context} />
@@ -611,6 +612,7 @@ function ExpandableItem(props: {
           Data.setContent(props.context.state, T.thing(props.context.tree, props.node), content),
         )
       }
+      hasFocus={T.hasFocus(props.context.tree, props.node)}
     />
   );
 

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -265,9 +265,7 @@ export interface EditorState {
 }
 
 export function Editor(props: {
-  context: Context;
   content: EditorContent;
-  node: T.NodeRef;
   onAction(action: Ac.ActionName): void;
   onOpenLink(target: string): void;
   onJumpLink(target: string): void;
@@ -276,6 +274,7 @@ export function Editor(props: {
   hasFocus: boolean;
   onPastedParagraphs(paragraphs: string[]): void;
   onEditorStateChanged(editorState: EditorState): void;
+  onOpenExternalUrl(url: string): void;
 }) {
   const contentRef = usePropRef(props.content);
   const onOpenLinkRef = usePropRef(props.onOpenLink);
@@ -285,6 +284,7 @@ export function Editor(props: {
   const onEditRef = usePropRef(props.onEdit);
   const onPastedParagraphsRef = usePropRef(props.onPastedParagraphs);
   const onEditorStateChangedRef = usePropRef(props.onEditorStateChanged);
+  const onOpenExternalUrlRef = usePropRef(props.onOpenExternalUrl);
 
   const ref = React.useRef<HTMLDivElement>(null);
 
@@ -316,7 +316,9 @@ export function Editor(props: {
   });
 
   const externalLinkDecorationPlugin = createExternalLinkDecorationPlugin({
-    openExternalUrl: props.context.openExternalUrl,
+    openExternalUrl(url: string) {
+      onOpenExternalUrlRef.current!(url);
+    },
   });
 
   const pastePlugin = new PS.Plugin({
@@ -448,7 +450,7 @@ export function Editor(props: {
     if (props.hasFocus || editorViewRef.current!.hasFocus()) return;
 
     editorViewRef.current!.updateState(recreateEditorState());
-  }, [props.hasFocus, props.node, props.content]);
+  }, [props.hasFocus, props.content]);
 
   return <div className="editor content" ref={ref}></div>;
 }

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -1,20 +1,18 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+
 import * as PS from "prosemirror-state";
 import * as PV from "prosemirror-view";
 import * as PM from "prosemirror-model";
-import {classes} from "@johv/miscjs";
+import ProseMirror from "./ProseMirror";
 
 import * as D from "../data";
 import * as T from "../tree";
 import * as E from "../editing";
 import * as Sh from "../shortcuts";
 import * as Ac from "../actions";
-import {AppState, Context, merge, setAppState} from "../context";
+import {AppState, merge} from "../context";
 
-import type {ItemStatus} from "./Item";
-
-import ProseMirror from "./ProseMirror";
 import Bullet from "./Bullet";
 
 // Sometimes we want to pass a callback to some function that doesn't know about
@@ -179,7 +177,7 @@ function createExternalLinkDecorationPlugin(args: {openExternalUrl(url: string):
 }
 
 function toProseMirror(
-  content: EditorContent,
+  content: E.EditorContent,
   args: {
     openLink: (link: string) => void;
     jumpLink: (link: string) => void;
@@ -212,8 +210,8 @@ function toProseMirror(
   return schema.node("doc", {}, nodes);
 }
 
-function fromProseMirror(doc: PM.Node<typeof schema>): EditorContent {
-  const content: EditorContent = [];
+function fromProseMirror(doc: PM.Node<typeof schema>): E.EditorContent {
+  const content: E.EditorContent = [];
 
   doc.forEach((node) => {
     if (node.isText) {
@@ -226,7 +224,7 @@ function fromProseMirror(doc: PM.Node<typeof schema>): EditorContent {
   return content;
 }
 
-export function contentEq(a: EditorContent, b: EditorContent): boolean {
+function contentEq(a: E.EditorContent, b: E.EditorContent): boolean {
   if (a.length !== b.length) return false;
 
   for (let i = 0; i < a.length; ++i) {
@@ -257,25 +255,13 @@ export function onPastedParagraphs(app: AppState, node: T.NodeRef, paragraphs: s
   return merge(app, {state, tree});
 }
 
-export function collate(content: D.Content, state: D.State): EditorContent {
-  return content.map((piece) => {
-    if (typeof piece === "string") {
-      return piece;
-    } else {
-      return {link: piece.link, title: D.exists(state, piece.link) ? D.contentText(state, piece.link) : null};
-    }
-  });
-}
-
-export type EditorContent = (string | {link: string; title: string | null})[];
-
 export interface EditorState {
   selection: string;
   replace(link: string, textContent: string): void;
 }
 
 export function Editor(props: {
-  content: EditorContent;
+  content: E.EditorContent;
   hasFocus: boolean;
   onAction(action: Ac.ActionName): void;
   onOpenLink(target: string): void;

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -330,13 +330,17 @@ export function Editor(props: {
     setEditorState(editorState.apply(transaction));
   }
 
+  // Send our changes to the parent.
   React.useEffect(() => {
-    // Avoid infinite loop:
-    if (!props.hasFocus) return;
     if (contentEq(props.content, fromProseMirror(editorState))) return;
-
     props.onEdit(fromProseMirror(editorState));
-  }, [props.onEdit, editorState]);
+  }, [editorState]);
+
+  // Receive parent's changes for us.
+  React.useEffect(() => {
+    if (contentEq(props.content, fromProseMirror(editorState))) return;
+    setEditorState(recreateEditorState());
+  }, [props.content]);
 
   React.useEffect(() => {
     onEditorStateChangedRef.current!({
@@ -354,16 +358,6 @@ export function Editor(props: {
       },
     });
   }, [editorState]);
-
-  // When our content gets updated via our props, we want to reflect those
-  // updates in the editor state.
-  React.useEffect(() => {
-    // Avoid infinite loop:
-    if (props.hasFocus) return;
-    if (contentEq(props.content, fromProseMirror(editorState))) return;
-
-    setEditorState(recreateEditorState());
-  }, [props.hasFocus, editorState, props.content]);
 
   return <ProseMirror state={editorState} onTransaction={onTransaction} hasFocus={props.hasFocus} />;
 }

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -259,6 +259,7 @@ export default function Editor(props: {
   onFocus(): void;
   content: D.Content;
   onEdit(content: D.Content): void;
+  hasFocus: boolean;
 }) {
   const stateRef = usePropRef(props.context.state);
   const contentRef = usePropRef(props.content);
@@ -382,7 +383,7 @@ export default function Editor(props: {
   }, []);
 
   React.useEffect(() => {
-    if (!T.hasFocus(props.context.tree, props.node)) return;
+    if (!props.hasFocus) return;
 
     editorViewRef.current!.focus();
 
@@ -422,7 +423,7 @@ export default function Editor(props: {
         editorViewRef.current!.dispatch(tr);
       },
     });
-  }, [T.focused(props.context.tree)]);
+  }, [props.hasFocus]);
 
   // When our content gets updated via our props, we want to reflect those
   // updates in the editor state.
@@ -433,10 +434,10 @@ export default function Editor(props: {
     // The node may be focused in the tree without the editor having focus
     // immediately after inserting a link. The editor may have focus without the
     // tree node having focus immediately after the user clicks on an editor.
-    if (T.focused(props.context.tree) === props.node || editorViewRef.current!.hasFocus()) return;
+    if (props.hasFocus || editorViewRef.current!.hasFocus()) return;
 
     editorViewRef.current!.updateState(recreateEditorState());
-  }, [props.context.tree, props.node, props.content]);
+  }, [props.hasFocus, props.node, props.content]);
 
   return <div className="editor content" ref={ref}></div>;
 }

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -256,7 +256,6 @@ export function onPastedParagraphs(app: AppState, node: T.NodeRef, paragraphs: s
 }
 
 export interface EditorState {
-  selection: string;
   replace(link: string, textContent: string): void;
 }
 
@@ -365,23 +364,7 @@ export function Editor(props: {
   }, [props.onEdit, editorState]);
 
   React.useEffect(() => {
-    // The popup that appears e.g. when inserting a link needs to have access
-    // to the current selection.
-    const textSelection = (() => {
-      let content: D.Content = [];
-      editorState.selection.content().content.forEach((node) => {
-        if (node.isText) {
-          content.push(node.textContent);
-        } else if (node.type.name === "link") {
-          content.push({link: node.attrs.target});
-        }
-      });
-      return E.contentToEditString(content);
-    })();
-
     onEditorStateChangedRef.current!({
-      selection: textSelection,
-
       replace(link: string, textContent: string): void {
         const tr = editorState.tr;
         const attrs: LinkAttrs = {

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -252,7 +252,6 @@ function onPastedParagraphs(app: AppState, node: T.NodeRef, paragraphs: string[]
 export default function Editor(props: {
   context: Context;
   node: T.NodeRef;
-  placeholder?: string;
   onAction(action: Ac.ActionName): void;
   onOpenLink(target: string): void;
   onJumpLink(target: string): void;

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -430,9 +430,13 @@ export default function Editor(props: {
   // When our content gets updated via our props, we want to reflect those
   // updates in the editor state.
   React.useEffect(() => {
-    // If we're the focused node, then the changes were probably made via this
-    // editor. In that case, we don't want to update the editor again.
-    if (T.focused(props.context.tree) === props.node) return;
+    // If we're focused, then the changes were probably made via this editor. In
+    // that case, we don't want to update the editor again.
+    //
+    // The node may be focused in the tree without the editor having focus
+    // immediately after inserting a link. The editor may have focus without the
+    // tree node having focus immediately after the user clicks on an editor.
+    if (T.focused(props.context.tree) === props.node || editorViewRef.current!.hasFocus()) return;
 
     editorViewRef.current!.updateState(recreateEditorState());
   }, [props.context.tree, props.node, props.content]);

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -244,7 +244,7 @@ export function Editor(props: {
   onOpenLink(target: string): void;
   onJumpLink(target: string): void;
   onFocus(): void;
-  onEdit(content: D.Content): void;
+  onEdit(editor: E.Editor): void;
   onPastedParagraphs(paragraphs: string[]): void;
   onEditorStateChanged(editorState: EditorState): void;
   onOpenExternalUrl(url: string): void;
@@ -333,7 +333,7 @@ export function Editor(props: {
   // Send our changes to the parent.
   React.useEffect(() => {
     if (contentEq(props.editor.content, fromProseMirror(editorState))) return;
-    props.onEdit(fromProseMirror(editorState));
+    props.onEdit({content: fromProseMirror(editorState), selection: {from: 0, to: 0}});
   }, [editorState]);
 
   // Receive parent's changes for us.

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -368,8 +368,7 @@ export default function Editor(props: {
       // We don't need to update anything if the transaction didn't actually
       // change any of the content.
       if (
-        E.contentToEditString(D.content(stateRef.current!, T.thing(treeRef.current!, props.node))) ===
-        E.contentToEditString(contentFromDoc(editorDoc))
+        D.contentEq(D.content(stateRef.current!, T.thing(treeRef.current!, props.node)), contentFromDoc(editorDoc))
       )
         return;
 

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -14,6 +14,7 @@ import {AppState, Context, merge, setAppState} from "../context";
 
 import type {ItemStatus} from "./Item";
 
+import ProseMirror from "./ProseMirror";
 import Bullet from "./Bullet";
 
 // Sometimes we want to pass a callback to some function that doesn't know about
@@ -279,37 +280,6 @@ export function collate(content: D.Content, state: D.State): EditorContent {
 export interface EditorState {
   selection: string;
   replace(link: string, textContent: string): void;
-}
-
-function ProseMirror<Schema extends PM.Schema>(props: {
-  state: PS.EditorState<Schema>;
-  onTransaction(transaction: PS.Transaction<Schema>, view: PV.EditorView<Schema>): void;
-  hasFocus: boolean;
-}) {
-  const onTransactionRef = usePropRef(props.onTransaction);
-
-  const editorViewRef = React.useRef<PV.EditorView<Schema> | null>(null);
-  const ref = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    function dispatchTransaction(this: PV.EditorView<Schema>, transaction: PS.Transaction<Schema>) {
-      onTransactionRef.current!(transaction, this);
-    }
-
-    editorViewRef.current = new PV.EditorView(ref.current!, {state: props.state, dispatchTransaction});
-  }, []);
-
-  React.useEffect(() => {
-    if (props.hasFocus) editorViewRef.current!.focus();
-  }, [props.hasFocus]);
-
-  React.useEffect(() => {
-    if (props.hasFocus && !editorViewRef.current!.hasFocus()) editorViewRef.current!.focus(); // Restore focus after inserting link from poup
-
-    editorViewRef.current?.updateState(props.state);
-  }, [props.hasFocus, props.state]);
-
-  return <div className="editor content" ref={ref}></div>;
 }
 
 export function Editor(props: {

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -258,14 +258,15 @@ export default function Editor(props: {
   onJumpLink(target: string): void;
   onFocus(): void;
   content: D.Content;
+  onEdit(content: D.Content): void;
 }) {
   const stateRef = usePropRef(props.context.state);
-  const treeRef = usePropRef(props.context.tree);
   const contentRef = usePropRef(props.content);
   const onOpenLinkRef = usePropRef(props.onOpenLink);
   const onJumpLinkRef = usePropRef(props.onJumpLink);
   const onActionRef = usePropRef(props.onAction);
   const onFocusRef = usePropRef(props.onFocus);
+  const onEditRef = usePropRef(props.onEdit);
 
   const ref = React.useRef<HTMLDivElement>(null);
 
@@ -360,8 +361,6 @@ export default function Editor(props: {
 
   const editorViewRef = React.useRef<PV.EditorView<typeof schema> | null>(null);
 
-  const setStateRef = usePropRef(props.context.setState);
-
   // Initialize editor
   React.useEffect(() => {
     function dispatchTransaction(this: PV.EditorView<typeof schema>, transaction: PS.Transaction<typeof schema>) {
@@ -376,9 +375,7 @@ export default function Editor(props: {
       // change any of the content.
       if (D.contentEq(contentRef.current!, contentFromDoc(editorDoc))) return;
 
-      setStateRef.current!(
-        D.setContent(stateRef.current!, T.thing(treeRef.current!, props.node), contentFromDoc(editorDoc)),
-      );
+      onEditRef.current!(contentFromDoc(editorDoc));
     }
 
     editorViewRef.current = new PV.EditorView(ref.current!, {state: initialState, dispatchTransaction});

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -127,7 +127,7 @@ function createExternalLinkDecorationPlugin(args: {openExternalUrl(url: string):
   return new PS.Plugin({
     props: {
       decorations(state: PS.EditorState<PM.Schema>) {
-        const ranges = E.externalLinkRanges(fromProseMirror(state));
+        const ranges = E.externalLinkRanges(fromProseMirror(state).content);
         return PV.DecorationSet.create(
           state.doc,
           ranges.map((range) =>
@@ -188,7 +188,7 @@ function toProseMirror(
   return result;
 }
 
-function fromProseMirror(proseMirrorEditorState: PS.EditorState<typeof schema>): E.EditorContent {
+function fromProseMirror(proseMirrorEditorState: PS.EditorState<typeof schema>): E.Editor {
   const content: E.EditorContent = [];
 
   proseMirrorEditorState.doc.forEach((node) => {
@@ -199,7 +199,9 @@ function fromProseMirror(proseMirrorEditorState: PS.EditorState<typeof schema>):
     }
   });
 
-  return content;
+  const selection = {from: proseMirrorEditorState.selection.anchor, to: proseMirrorEditorState.selection.head};
+
+  return {content, selection};
 }
 
 function contentEq(a: E.EditorContent, b: E.EditorContent): boolean {
@@ -332,13 +334,13 @@ export function Editor(props: {
 
   // Send our changes to the parent.
   React.useEffect(() => {
-    if (contentEq(props.editor.content, fromProseMirror(editorState))) return;
-    props.onEdit({content: fromProseMirror(editorState), selection: {from: 0, to: 0}});
+    if (contentEq(props.editor.content, fromProseMirror(editorState).content)) return;
+    props.onEdit(fromProseMirror(editorState));
   }, [editorState]);
 
   // Receive parent's changes for us.
   React.useEffect(() => {
-    if (contentEq(props.editor.content, fromProseMirror(editorState))) return;
+    if (contentEq(props.editor.content, fromProseMirror(editorState).content)) return;
     setEditorState(recreateEditorState());
   }, [props.editor]);
 

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -242,12 +242,14 @@ export default function Editor(props: {
   onAction(action: Ac.ActionName): void;
   onOpenLink(target: string): void;
   onJumpLink(target: string): void;
+  onFocus(): void;
 }) {
   const stateRef = usePropRef(props.context.state);
   const treeRef = usePropRef(props.context.tree);
   const onOpenLinkRef = usePropRef(props.onOpenLink);
   const onJumpLinkRef = usePropRef(props.onJumpLink);
   const onActionRef = usePropRef(props.onAction);
+  const onFocusRef = usePropRef(props.onFocus);
 
   const ref = React.useRef<HTMLDivElement>(null);
 
@@ -316,8 +318,7 @@ export default function Editor(props: {
   const focusPlugin = new PS.Plugin({
     props: {
       handleClick(view, pos, ev) {
-        props.context.setTree(T.focus(treeRef.current!, props.node));
-
+        onFocusRef.current!();
         return false;
       },
     },

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -146,7 +146,7 @@ function createExternalLinkDecorationPlugin(args: {openExternalUrl(url: string):
 }
 
 function toProseMirror(
-  content: E.EditorContent,
+  editor: E.Editor,
   args: {
     openLink: (link: string) => void;
     jumpLink: (link: string) => void;
@@ -155,7 +155,7 @@ function toProseMirror(
 ): PS.EditorState<typeof schema> {
   const nodes = [];
 
-  for (const contentNode of content) {
+  for (const contentNode of editor.content) {
     if (typeof contentNode === "string") {
       if (contentNode === "") {
         // Empty text nodes are not allowed by ProseMirror.
@@ -238,7 +238,7 @@ export interface EditorState {
 }
 
 export function Editor(props: {
-  content: E.EditorContent;
+  editor: E.Editor;
   hasFocus: boolean;
   onAction(action: Ac.ActionName): void;
   onOpenLink(target: string): void;
@@ -317,7 +317,7 @@ export function Editor(props: {
   });
 
   function recreateEditorState() {
-    return toProseMirror(props.content, {
+    return toProseMirror(props.editor, {
       openLink: (thing) => onOpenLinkRef.current!(thing),
       jumpLink: (thing) => onJumpLinkRef.current!(thing),
       plugins: [keyPlugin, pastePlugin, externalLinkDecorationPlugin, focusPlugin],
@@ -332,15 +332,15 @@ export function Editor(props: {
 
   // Send our changes to the parent.
   React.useEffect(() => {
-    if (contentEq(props.content, fromProseMirror(editorState))) return;
+    if (contentEq(props.editor.content, fromProseMirror(editorState))) return;
     props.onEdit(fromProseMirror(editorState));
   }, [editorState]);
 
   // Receive parent's changes for us.
   React.useEffect(() => {
-    if (contentEq(props.content, fromProseMirror(editorState))) return;
+    if (contentEq(props.editor.content, fromProseMirror(editorState))) return;
     setEditorState(recreateEditorState());
-  }, [props.content]);
+  }, [props.editor]);
 
   React.useEffect(() => {
     onEditorStateChangedRef.current!({

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -235,7 +235,7 @@ function contentFromDoc(doc: PM.Node<typeof schema>): D.Content {
   return content;
 }
 
-function onPastedParagraphs(app: AppState, node: T.NodeRef, paragraphs: string[]): AppState {
+export function onPastedParagraphs(app: AppState, node: T.NodeRef, paragraphs: string[]) {
   let [state, tree] = [app.state, app.tree];
   let lastNode = node;
 
@@ -249,7 +249,7 @@ function onPastedParagraphs(app: AppState, node: T.NodeRef, paragraphs: string[]
   return merge(app, {state, tree});
 }
 
-export default function Editor(props: {
+export function Editor(props: {
   context: Context;
   node: T.NodeRef;
   onAction(action: Ac.ActionName): void;
@@ -259,6 +259,7 @@ export default function Editor(props: {
   content: D.Content;
   onEdit(content: D.Content): void;
   hasFocus: boolean;
+  onPastedParagraphs(paragraphs: string[]): void;
 }) {
   const stateRef = usePropRef(props.context.state);
   const contentRef = usePropRef(props.content);
@@ -267,6 +268,7 @@ export default function Editor(props: {
   const onActionRef = usePropRef(props.onAction);
   const onFocusRef = usePropRef(props.onFocus);
   const onEditRef = usePropRef(props.onEdit);
+  const onPastedParagraphsRef = usePropRef(props.onPastedParagraphs);
 
   const ref = React.useRef<HTMLDivElement>(null);
 
@@ -307,8 +309,7 @@ export default function Editor(props: {
         const text = ev.clipboardData?.getData("text/plain");
 
         if (text !== undefined && E.isParagraphFormattedText(text)) {
-          const paragraphs = E.paragraphs(text);
-          setAppState(props.context, onPastedParagraphs(props.context, props.node, paragraphs));
+          onPastedParagraphsRef.current!(E.paragraphs(text));
           return true;
         }
 

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -235,7 +235,7 @@ function contentFromDoc(doc: PM.Node<typeof schema>): D.Content {
   return content;
 }
 
-function ContentEditor(props: {
+export default function Editor(props: {
   context: Context;
   node: T.NodeRef;
   placeholder?: string;
@@ -458,15 +458,4 @@ function ContentEditor(props: {
   }, [T.focused(props.context.tree)]);
 
   return <div className="editor content" ref={ref}></div>;
-}
-
-export default function Editor(props: {
-  context: Context;
-  node: T.NodeRef;
-  placeholder?: string;
-  onAction(action: Ac.ActionName): void;
-  onOpenLink(target: string): void;
-  onJumpLink(target: string): void;
-}) {
-  return <ContentEditor {...props} />;
 }

--- a/src/client/src/ui/Editor.tsx
+++ b/src/client/src/ui/Editor.tsx
@@ -179,10 +179,13 @@ function toProseMirror(
 
   const doc = schema.node("doc", {}, nodes);
 
+  const selection = new PS.TextSelection(doc.resolve(editor.selection.from), doc.resolve(editor.selection.to));
+
   let result = PS.EditorState.create({
     schema,
     doc: doc,
     plugins: args.plugins,
+    selection,
   });
 
   return result;

--- a/src/client/src/ui/ProseMirror.tsx
+++ b/src/client/src/ui/ProseMirror.tsx
@@ -1,0 +1,52 @@
+import * as PS from "prosemirror-state";
+import * as PV from "prosemirror-view";
+import * as PM from "prosemirror-model";
+
+import * as React from "react";
+
+// Sometimes we want to pass a callback to some function that doesn't know about
+// React, but which should still have access to the latest value of a prop
+// passed to a component.
+//
+// This function lets us make the latest value of a prop available as a ref,
+// which we can then dereference from inside such a callback.
+//
+// We use this when integrating with ProseMirror.
+function usePropRef<T>(prop: T): React.RefObject<T> {
+  const ref = React.useRef(prop);
+  React.useEffect(() => {
+    ref.current = prop;
+  }, [prop]);
+  return ref;
+}
+
+export default function ProseMirror<Schema extends PM.Schema>(props: {
+  state: PS.EditorState<Schema>;
+  onTransaction(transaction: PS.Transaction<Schema>, view: PV.EditorView<Schema>): void;
+  hasFocus: boolean;
+}) {
+  const onTransactionRef = usePropRef(props.onTransaction);
+
+  const editorViewRef = React.useRef<PV.EditorView<Schema> | null>(null);
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    function dispatchTransaction(this: PV.EditorView<Schema>, transaction: PS.Transaction<Schema>) {
+      onTransactionRef.current!(transaction, this);
+    }
+
+    editorViewRef.current = new PV.EditorView(ref.current!, {state: props.state, dispatchTransaction});
+  }, []);
+
+  React.useEffect(() => {
+    if (props.hasFocus) editorViewRef.current!.focus();
+  }, [props.hasFocus]);
+
+  React.useEffect(() => {
+    if (props.hasFocus && !editorViewRef.current!.hasFocus()) editorViewRef.current!.focus(); // Restore focus after inserting link from poup
+
+    editorViewRef.current?.updateState(props.state);
+  }, [props.hasFocus, props.state]);
+
+  return <div className="editor content" ref={ref}></div>;
+}

--- a/src/client/tests/editing.test.ts
+++ b/src/client/tests/editing.test.ts
@@ -48,7 +48,7 @@ describe("loading editor from application state", () => {
     state = D.setContent(state, "0", ["Item 0"]);
     state = D.setContent(state, "1", ["Item 1 has link to ", {link: "0"}, "."]);
 
-    const content = E.collate(D.content(state, "1"), state);
+    const content = E.load(D.content(state, "1"), state).content;
 
     expect(content).toEqual(["Item 1 has link to ", {link: "0", title: "Item 0"}, "."]);
   });

--- a/src/client/tests/editing.test.ts
+++ b/src/client/tests/editing.test.ts
@@ -101,3 +101,25 @@ describe("inserting a link while having some text selected", () => {
     expect(after.selection).toEqual({from: 9, to: 9});
   });
 });
+
+describe("when converting editor content to plain data content", () => {
+  const editor: E.Editor = {
+    content: ["This is a link: ", {link: "2", title: "Item 2"}, "."],
+    selection: {from: 0, to: 0},
+  };
+
+  const content = E.produceContent(editor);
+
+  test("the text segments are the same", () => {
+    expect(content[0]).toBe("This is a link: ");
+    expect(content[2]).toBe(".");
+  });
+
+  test("the links mention only the IDs of each linked item", () => {
+    expect(content[1]).toEqual({link: "2"});
+  });
+
+  test("there aren't any other segments added", () => {
+    expect(content.length).toBe(3);
+  });
+});

--- a/src/client/tests/editing.test.ts
+++ b/src/client/tests/editing.test.ts
@@ -84,3 +84,20 @@ describe("external link decorations", () => {
     expect(E.externalLinkRanges(["An example (https://example.com) it is."])).toEqual([{from: 12, to: 31}]);
   });
 });
+
+describe("inserting a link while having some text selected", () => {
+  const before: E.Editor = {
+    content: ["This is just some text. How about that?"],
+    selection: {from: 8, to: 22},
+  };
+
+  const after = E.insertLink(before, {link: "1234", title: "my very own link"});
+
+  it("modifies the content to contain the link", () => {
+    expect(after.content).toEqual(["This is ", {link: "1234", title: "my very own link"}, ". How about that?"]);
+  });
+
+  it("places the selection after the link", () => {
+    expect(after.selection).toEqual({from: 9, to: 9});
+  });
+});

--- a/src/client/tests/editing.test.ts
+++ b/src/client/tests/editing.test.ts
@@ -53,3 +53,34 @@ describe("loading editor from application state", () => {
     expect(content).toEqual(["Item 1 has link to ", {link: "0", title: "Item 0"}, "."]);
   });
 });
+
+describe("external link decorations", () => {
+  test("when there are no external links in the text, there are no decorations", () => {
+    expect(E.externalLinkRanges(["No external links here!"])).toEqual([]);
+  });
+
+  test("an external link inside a single text node is detected", () => {
+    expect(E.externalLinkRanges(["Link to https://example.com should be detected!"])).toEqual([{from: 8, to: 27}]);
+  });
+
+  test("an external link after an internal link is detected", () => {
+    expect(
+      E.externalLinkRanges([
+        "First, ",
+        {link: "0", title: "an internal link"},
+        ". And now: https://example.com should still be detected!",
+      ]),
+    ).toEqual([{from: 19, to: 38}]);
+  });
+
+  test("multiple links in the same text fragment are detected", () => {
+    expect(E.externalLinkRanges(["First, https://example.com. And now https://another.example.com."])).toEqual([
+      {from: 7, to: 26},
+      {from: 36, to: 63},
+    ]);
+  });
+
+  test("when a link is enclosed in parentheses, the closing parenthesis is not part of the link", () => {
+    expect(E.externalLinkRanges(["An example (https://example.com) it is."])).toEqual([{from: 12, to: 31}]);
+  });
+});

--- a/src/client/tests/editing.test.ts
+++ b/src/client/tests/editing.test.ts
@@ -1,38 +1,55 @@
 /// <reference types="@types/jest" />
 
+import * as D from "../src/data";
+
 import * as E from "../src/editing";
 
-test("Single line is not paragraph formatted", () => {
-  expect(E.isParagraphFormattedText("This is a line of text.")).toBeFalsy();
+describe("paragraphs", () => {
+  test("Single line is not paragraph formatted", () => {
+    expect(E.isParagraphFormattedText("This is a line of text.")).toBeFalsy();
+  });
+
+  test("Two lines separated by single line break are not paragraphs", () => {
+    expect(E.isParagraphFormattedText("This is a line of text.\nHere is another line.")).toBeFalsy();
+  });
+
+  test("Two lines separated by double line break are paragraphs", () => {
+    expect(
+      E.isParagraphFormattedText("This is the first paragraph.\n\nThis is the second paragraph."),
+    ).toBeTruthy();
+  });
+
+  test("Paragraphs are split at double line break", () => {
+    expect(E.paragraphs("1 2 3\n\n4 5 6\n\n7 8 9")).toEqual(["1 2 3", "4 5 6", "7 8 9"]);
+  });
+
+  test("Can also use CRLF style line endings", () => {
+    expect(E.paragraphs("1 2 3\r\n\r\n4 5 6\r\n\r\n7 8 9")).toEqual(["1 2 3", "4 5 6", "7 8 9"]);
+  });
+
+  test("Final line breaks don't make any difference for paragraphs", () => {
+    expect(E.paragraphs("1 2 3\n\n4 5 6\n\n7 8 9\n")).toEqual(["1 2 3", "4 5 6", "7 8 9"]);
+  });
+
+  test("Paragraphs can be separated by extra line breaks", () => {
+    expect(E.paragraphs("1 2 3\n\n4 5 6\n\n\n\n7 8 9\n\n")).toEqual(["1 2 3", "4 5 6", "7 8 9"]);
+  });
+
+  test("Line breaks are converted to spaces inside paragraphs", () => {
+    expect(E.paragraphs("1 2 3\n4 5 6\n\n7 8 9")).toEqual(["1 2 3 4 5 6", "7 8 9"]);
+    expect(E.paragraphs("1 2 3\r\n4 5 6\r\n\r\n7 8 9")).toEqual(["1 2 3 4 5 6", "7 8 9"]);
+  });
 });
 
-test("Two lines separated by single line break are not paragraphs", () => {
-  expect(E.isParagraphFormattedText("This is a line of text.\nHere is another line.")).toBeFalsy();
-});
+describe("loading editor from application state", () => {
+  it("annotates links with their content", () => {
+    let state = D.empty;
+    state = D.create(state, "1")[0];
+    state = D.setContent(state, "0", ["Item 0"]);
+    state = D.setContent(state, "1", ["Item 1 has link to ", {link: "0"}, "."]);
 
-test("Two lines separated by double line break are paragraphs", () => {
-  expect(
-    E.isParagraphFormattedText("This is the first paragraph.\n\nThis is the second paragraph."),
-  ).toBeTruthy();
-});
+    const content = E.collate(D.content(state, "1"), state);
 
-test("Paragraphs are split at double line break", () => {
-  expect(E.paragraphs("1 2 3\n\n4 5 6\n\n7 8 9")).toEqual(["1 2 3", "4 5 6", "7 8 9"]);
-});
-
-test("Can also use CRLF style line endings", () => {
-  expect(E.paragraphs("1 2 3\r\n\r\n4 5 6\r\n\r\n7 8 9")).toEqual(["1 2 3", "4 5 6", "7 8 9"]);
-});
-
-test("Final line breaks don't make any difference for paragraphs", () => {
-  expect(E.paragraphs("1 2 3\n\n4 5 6\n\n7 8 9\n")).toEqual(["1 2 3", "4 5 6", "7 8 9"]);
-});
-
-test("Paragraphs can be separated by extra line breaks", () => {
-  expect(E.paragraphs("1 2 3\n\n4 5 6\n\n\n\n7 8 9\n\n")).toEqual(["1 2 3", "4 5 6", "7 8 9"]);
-});
-
-test("Line breaks are converted to spaces inside paragraphs", () => {
-  expect(E.paragraphs("1 2 3\n4 5 6\n\n7 8 9")).toEqual(["1 2 3 4 5 6", "7 8 9"]);
-  expect(E.paragraphs("1 2 3\r\n4 5 6\r\n\r\n7 8 9")).toEqual(["1 2 3 4 5 6", "7 8 9"]);
+    expect(content).toEqual(["Item 1 has link to ", {link: "0", title: "Item 0"}, "."]);
+  });
 });

--- a/src/desktop/package-lock.json
+++ b/src/desktop/package-lock.json
@@ -1380,9 +1380,9 @@
       }
     },
     "@thinktool/client": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@thinktool/client/-/client-3.4.3.tgz",
-      "integrity": "sha512-CRlZ+lfHr7oDlaczym/rDQMPf9LUCQk68XFEsoY2jsObqn0M6kjXXn6cqnR645a2XasPyN1GwfAxbmiRpJKhUA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@thinktool/client/-/client-3.4.4.tgz",
+      "integrity": "sha512-QoFxr/VFmwi0ToVQQPk9A7Yio24vQOLNgwH7Za3FlGb5WiFCia/Tc+xR2afcCsD+B7C/Znq5iISPgNXLm1A/Mg==",
       "requires": {
         "@johv/miscjs": "^1.6.0",
         "@thinktool/shared": "^2.0.0",
@@ -4484,9 +4484,9 @@
       "dev": true
     },
     "fuse.js": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.3.tgz",
-      "integrity": "sha512-JNgngolukIrqwayWnvy6NLH63hmwKPhm63o0uyBg51jPD0j09IvAzlV1rTXfAsgxpghI7khAo6Mv+EmvjDWXig=="
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.5.tgz",
+      "integrity": "sha512-AIHjOhexWVqs/jWqun6jTUfdXB3Bm1uShoirHvTZImD2kHEQZ1zOmoDEqIPs8N1LnnwXJeG0T+r9ilEeJzlaoA=="
     },
     "gauge": {
       "version": "2.7.4",
@@ -7662,9 +7662,9 @@
       "dev": true
     },
     "prosemirror-model": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.13.0.tgz",
-      "integrity": "sha512-j5F0Wt5Me8a1qKI6xNRNET6l07tWTpXwxfcs7xTl5PWAxJGgAC+vHIuwenGZMWSE6kU2k4qr55pw5aFXlUfgVA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.13.1.tgz",
+      "integrity": "sha512-PNH+b5bilAJi1B5yJ8QzoNY3ZV+nlD0jKG3XCBk7PmE/YUTJomBkFBS005vfU+3M9yeVR8/6spAEDsfVFUhNeQ==",
       "requires": {
         "orderedmap": "^1.1.0"
       }

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -18,7 +18,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@thinktool/client": "^3.4.3",
+    "@thinktool/client": "^3.4.4",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "sqlite": "^4.0.18",

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -258,9 +258,9 @@
       "integrity": "sha512-XtzzPX2R4+MIyu1waEQUo2tiNwWVEkmObA6pboRCDTPOs4Ri8ckaIE08lN5A5opyF6GVN+IEq/J8KQrgsePsZQ=="
     },
     "@thinktool/client": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@thinktool/client/-/client-3.4.3.tgz",
-      "integrity": "sha512-CRlZ+lfHr7oDlaczym/rDQMPf9LUCQk68XFEsoY2jsObqn0M6kjXXn6cqnR645a2XasPyN1GwfAxbmiRpJKhUA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@thinktool/client/-/client-3.4.4.tgz",
+      "integrity": "sha512-QoFxr/VFmwi0ToVQQPk9A7Yio24vQOLNgwH7Za3FlGb5WiFCia/Tc+xR2afcCsD+B7C/Znq5iISPgNXLm1A/Mg==",
       "requires": {
         "@johv/miscjs": "^1.6.0",
         "@thinktool/shared": "^2.0.0",
@@ -2220,9 +2220,9 @@
       "optional": true
     },
     "fuse.js": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.3.tgz",
-      "integrity": "sha512-JNgngolukIrqwayWnvy6NLH63hmwKPhm63o0uyBg51jPD0j09IvAzlV1rTXfAsgxpghI7khAo6Mv+EmvjDWXig=="
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.5.tgz",
+      "integrity": "sha512-AIHjOhexWVqs/jWqun6jTUfdXB3Bm1uShoirHvTZImD2kHEQZ1zOmoDEqIPs8N1LnnwXJeG0T+r9ilEeJzlaoA=="
     },
     "gauge": {
       "version": "2.7.4",
@@ -3742,9 +3742,9 @@
       }
     },
     "prosemirror-model": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.13.0.tgz",
-      "integrity": "sha512-j5F0Wt5Me8a1qKI6xNRNET6l07tWTpXwxfcs7xTl5PWAxJGgAC+vHIuwenGZMWSE6kU2k4qr55pw5aFXlUfgVA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.13.1.tgz",
+      "integrity": "sha512-PNH+b5bilAJi1B5yJ8QzoNY3ZV+nlD0jKG3XCBk7PmE/YUTJomBkFBS005vfU+3M9yeVR8/6spAEDsfVFUhNeQ==",
       "requires": {
         "orderedmap": "^1.1.0"
       }

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -14,7 +14,7 @@
     "link-client": "npm ci && npm link ../client && npm link node_modules/@thinktool/client/node_modules/react && npm link node_modules/@thinktool/client/node_modules/react-dom"
   },
   "dependencies": {
-    "@thinktool/client": "^3.4.3",
+    "@thinktool/client": "^3.4.4",
     "next": "^10.0.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
This is a follow-up to previous refactoring commits like 970b81d and 29d6257. The overall goal is to make our code more testable. We still have a while to go.

This commit does simplify the logic in the `<Editor>` component itself, and instead moves some of that logic into a separate module, called `editing.ts`, which has some unit tests.

We also removed some dead core for broken features, namely indicating open links in the editor itself (561bd34) and loading selected text into the popup (
c9de314).